### PR TITLE
fix compiler warnings

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -33,8 +33,8 @@ SOFTWARE.
 #include "ssd1306.h"
 #include "font.h"
 
-inline static void swap(uint32_t *a, uint32_t *b) {
-    uint32_t *t=a;
+inline static void swap(int32_t *a, int32_t *b) {
+    int32_t *t=a;
     *a=*b;
     *b=*t;
 }
@@ -190,7 +190,7 @@ void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t 
         uint8_t line=(uint8_t)(font[(c-0x20)*font[1]+i+2]);
 
         for(int8_t j=0; j<font[0]; ++j, line>>=1) {
-            if(line & 1 ==1)
+            if((line & 1) ==1)
                 ssd1306_draw_square(p, x+i*scale, y+j*scale, scale, scale);
         }
     }


### PR DESCRIPTION
Fixes warnings:

> pico-ssd1306/ssd1306.c: In function 'ssd1306_draw_line': > pico-ssd1306/ssd1306.c:151:14: warning: pointer targets in passing argument 1 of 'swap' differ in signedness [-Wpointer-sign]
>   151 |         swap(&x1, &x2);

and:

> /home/jajcus/Dropbox/Modular/pico/screen_test/pico-ssd1306/ssd1306.c:193:21: warning: suggest parentheses around comparison in operand of '&' [-Wparentheses]
>   193 |             if(line & 1 ==1)