### PR TITLE
Add ssd1306_clear_pixel function

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -140,6 +140,12 @@ inline void ssd1306_clear(ssd1306_t *p) {
     memset(p->buffer, 0, p->bufsize);
 }
 
+void ssd1306_clear_pixel(ssd1306_t *p, uint32_t x, uint32_t y) {
+    if(x>=p->width || y>=p->height) return;
+
+    p->buffer[x+p->width*(y>>3)]&=~(0x1<<(y&0x07));
+}
+
 void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y) {
     if(x>=p->width || y>=p->height) return;
 

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -144,6 +144,15 @@ void ssd1306_show(ssd1306_t *p);
 void ssd1306_clear(ssd1306_t *p);
 
 /**
+	@brief clear pixel on buffer
+
+	@param[in] p : instance of display
+	@param[in] x : x position
+	@param[in] y : y position
+*/
+void ssd1306_clear_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
+
+/**
 	@brief draw pixel on buffer
 
 	@param[in] p : instance of display


### PR DESCRIPTION
It is useful to have a function that works opposite to `ssd1306_draw_pixel(..)`. It allows to clear only part of the screen or remove pixels to create effects as you can see in the following image.

In the background, you can see the faded menu and on the top, there is a kind of popup message or alert.
![display](https://user-images.githubusercontent.com/779950/236015228-64a977f0-8a60-40b4-8f8f-d78fb08a4f6f.jpg)
