### PR TITLE
Add ssd1306_clear_square function

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -174,11 +174,16 @@ void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t
     }
 }
 
+void ssd1306_clear_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+    for(uint32_t i=0; i<width; ++i)
+        for(uint32_t j=0; j<height; ++j)
+            ssd1306_clear_pixel(p, x+i, y+j);
+}
+
 void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
     for(uint32_t i=0; i<width; ++i)
         for(uint32_t j=0; j<height; ++j)
             ssd1306_draw_pixel(p, x+i, y+j);
-
 }
 
 void ssd1306_draw_empty_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -173,6 +173,17 @@ void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
 void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t y2);
 
 /**
+	@brief clear square at given position with given size
+
+	@param[in] p : instance of display
+	@param[in] x : x position of starting point
+	@param[in] y : y position of starting point
+	@param[in] width : width of square
+	@param[in] height : height of square
+*/
+void ssd1306_clear_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+
+/**
 	@brief draw filled square at given position with given size
 
 	@param[in] p : instance of display

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -162,7 +162,7 @@ void ssd1306_clear_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
 void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
 
 /**
-	@brief draw pixel on buffer
+	@brief draw line on buffer
 
 	@param[in] p : instance of display
 	@param[in] x1 : x position of starting point


### PR DESCRIPTION
It is expansion of idea introduced in PR https://github.com/daschr/pico-ssd1306/pull/11
Funtion to clear area defined as square instead of single pixels may be simpler to use in some cases, at least in my opinion.

Also corrected single typo in `ssd1306.h` file

See an example:

```
#define FONT font_8x5
#define FONT_WIDTH (FONT[1]+FONT[2])
#define FONT_HEIGHT (FONT[0])
#define OLED_WIDTH 128
#define OLED_HEIGHT 64
#define OLED_ADR 0x3C
#define OLED_I2C i2c1

// initialization
static ssd1306_t oled;
ssd1306_init(&oled, OLED_WIDTH, OLED_HEIGHT, OLED_ADR, OLED_I2C);
oled.external_vcc = true;

// displaying something...

// clear one line of text 
ssd1306_clear_square(&oled, 0, 0, OLED_WIDTH-1, FONT_HEIGHT);
```
