### PR TITLE
Add DMA engine to write the display buffer into the Display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+build/
+.cache/

--- a/basic_font.h
+++ b/basic_font.h
@@ -1,0 +1,13 @@
+#ifndef _basic_font_h
+#define _basic_font_h
+#include "font.h"
+#include "font_struct.h"
+
+const font basic_font = {
+	.bytes_per_char = 5,
+	.char_width = 5,
+	.first_char_in_font = 32,
+	.char_height = 8,
+	.bitmap_buffer = (char *)&font_8x5[5],
+};
+#endif

--- a/example/BMSPA_font.h
+++ b/example/BMSPA_font.h
@@ -103,7 +103,7 @@ const uint8_t BMSPA_font[] = {
 	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
 };
 
-const font bmspa_font = {
+const font bmspa = {
 	.bitmap_buffer =  (const char *)&BMSPA_font[5] ,
 	.first_char_in_font = 32,
 	.bytes_per_char = 8,

--- a/example/BMSPA_font.h
+++ b/example/BMSPA_font.h
@@ -1,3 +1,8 @@
+#ifndef _bmspa_font_h
+#define _bmspa_font_h
+#include <stdint.h>
+#include "font_struct.h"
+
 const uint8_t BMSPA_font[] = {
 	8, 8, 0, 32, 126,
 	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //  
@@ -97,3 +102,12 @@ const uint8_t BMSPA_font[] = {
 	0x02,0x01,0x01,0x02,0x02,0x01,0x00,0x00, // ~
 	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
 };
+
+const font bmspa_font = {
+	.bitmap_buffer =  (const char *)&BMSPA_font[5] ,
+	.first_char_in_font = 32,
+	.bytes_per_char = 8,
+	.char_width = 8,
+	.char_height = 8,
+};
+#endif

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,6 +7,7 @@ include(pico_sdk_import.cmake)
 project(ssd1306-example)
 
 set(CMAKE_C_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # initialize the Raspberry Pi Pico SDK
 pico_sdk_init()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,6 +8,7 @@ project(ssd1306-example)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+option(USE_DMA_FOR_DISPLAY "Use the DMA engine to move the display buffer to the display" OFF)
 
 # initialize the Raspberry Pi Pico SDK
 pico_sdk_init()
@@ -22,6 +23,17 @@ target_include_directories(ssd1306-example
     PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../
 )
+
+if(USE_DMA_FOR_DISPLAY)
+  message(STATUS "Using DMA")
+  target_compile_definitions(ssd1306-example
+    PUBLIC SSD1306_USE_DMA
+  )
+  target_link_libraries(ssd1306-example
+    hardware_dma
+  )
+endif(USE_DMA_FOR_DISPLAY)
+
 
 target_link_libraries(ssd1306-example pico_stdlib hardware_i2c)
 

--- a/example/acme_5_outlines_font.h
+++ b/example/acme_5_outlines_font.h
@@ -1,3 +1,8 @@
+#ifndef _acme_font_h
+#define _acme_font_h
+#include <stdint.h>
+#include "font_struct.h"
+
 const uint8_t acme_font[] = {
 	8, 6, 1, 32, 126,
 	0x00,0x00,0x00,0x00,0x00,0x00, //  
@@ -97,3 +102,12 @@ const uint8_t acme_font[] = {
 	0x0f,0x09,0x0d,0x09,0x0b,0x09, // ~
 	0x00,0x00,0x00,0x00,0x00,0x00
 };
+
+const font acme = {
+	.bitmap_buffer =  (const char *)&acme_font[5] ,
+	.first_char_in_font = 32,
+	.bytes_per_char = 6,
+	.char_width = 6,
+	.char_height = 8,
+};
+#endif

--- a/example/bubblesstandard_font.h
+++ b/example/bubblesstandard_font.h
@@ -1,3 +1,8 @@
+#ifndef _bubblesstandard_font_h
+#define _bmspa_font_h
+#include <stdint.h>
+#include "font_struct.h"
+
 const uint8_t bubblesstandard_font[] = {
 	8, 7, 0, 32, 126,
 	0x00,0x00,0x00,0x00,0x00,0x00,0x00, //  
@@ -97,3 +102,12 @@ const uint8_t bubblesstandard_font[] = {
 	0x10,0x08,0x08,0x10,0x10,0x08,0x00, // ~
 	0x00,0x00,0x00,0x00,0x00,0x00,0x00
 };
+
+const font bubblesstandard = {
+	.bitmap_buffer =  (const char *)&bubblesstandard_font[5] ,
+	.first_char_in_font = 32,
+	.bytes_per_char = 7,
+	.char_width = 7,
+	.char_height = 8,
+};
+#endif

--- a/example/bubblesstandard_font.h
+++ b/example/bubblesstandard_font.h
@@ -1,5 +1,5 @@
 #ifndef _bubblesstandard_font_h
-#define _bmspa_font_h
+#define _bubblesstandard_font_h
 #include <stdint.h>
 #include "font_struct.h"
 

--- a/example/crackers_font.h
+++ b/example/crackers_font.h
@@ -1,3 +1,8 @@
+#ifndef _crackers_font_h
+#define _crackers_font_h
+#include <stdint.h>
+#include "font_struct.h"
+
 const unsigned char crackers_font[] = {
 	8, 6, 2, 32, 126,
 	0x00,0x00,0x00,0x00,0x00,0x00, //  
@@ -97,3 +102,12 @@ const unsigned char crackers_font[] = {
 	0x04,0x06,0x06,0x02,0x04,0x06, // ~
 	0x00,0x00,0x00,0x00,0x00,0x00
 };
+
+const font crackers = {
+	.bitmap_buffer =  (const char *)&crackers_font[5] ,
+	.first_char_in_font = 32,
+	.bytes_per_char = 6,
+	.char_width = 6,
+	.char_height = 8,
+};
+#endif

--- a/example/example.c
+++ b/example/example.c
@@ -10,11 +10,16 @@
 #include "bubblesstandard_font.h"
 #include "crackers_font.h"
 #include "BMSPA_font.h"
+#include "font.h"
 
 const uint8_t num_chars_per_disp[]={7,7,7,5};
-const uint8_t *fonts[4]= {acme_font, bubblesstandard_font, crackers_font, BMSPA_font};
+const uint8_t *fonts[] = {acme_font, bubblesstandard_font, crackers_font, BMSPA_font};
 
-#define SLEEPTIME 25
+#define SLEEPTIME 30
+#ifdef SSD1306_USE_DMA
+CREATE_DISPLAY(128, 64, i2c1, 0x3C, 0, 0, 01) ;
+#endif
+
 
 void setup_gpios(void);
 void animation(void);
@@ -40,14 +45,22 @@ void setup_gpios(void) {
     gpio_pull_up(3);
 }
 
+void ssd1306_draw_string(ssd1306_t *disp, uint32_t x, uint32_t y, uint32_t scale, const char *s) { 
+    ssd1306_draw_string_with_font(disp, x, y, scale, font_8x5, s);
+}
+
 
 void animation(void) {
     const char *words[]= {"SSD1306", "DISPLAY", "DRIVER"};
 
-    ssd1306_t disp;
-    disp.external_vcc=false;
-    ssd1306_init(&disp, 128, 64, 0x3C, i2c1);
-    ssd1306_clear(&disp);
+#ifdef SSD1306_USE_DMA
+    ssd1306_init(&display_01);        
+#else
+    ssd1306_t display_01;
+    display_01.external_vcc=false;
+    ssd1306_init(&display_01, 128, 64, 0x3C, i2c1);
+#endif
+    ssd1306_clear(&display_01);
 
     printf("ANIMATION!\n");
 
@@ -55,33 +68,33 @@ void animation(void) {
 
     for(;;) {
         for(int y=0; y<31; ++y) {
-            ssd1306_draw_line(&disp, 0, y, 127, y);
-            ssd1306_show(&disp);
+            ssd1306_draw_line(&display_01, 0, y, 127, y);
+            ssd1306_show(&display_01);
             sleep_ms(SLEEPTIME);
-            ssd1306_clear(&disp);
+            ssd1306_clear(&display_01);
         }
 
         for(int y=0, i=1; y>=0; y+=i) {
-            ssd1306_draw_line(&disp, 0, 31-y, 127, 31+y);
-            ssd1306_draw_line(&disp, 0, 31+y, 127, 31-y);
-            ssd1306_show(&disp);
+            ssd1306_draw_line(&display_01, 0, 31-y, 127, 31+y);
+            ssd1306_draw_line(&display_01, 0, 31+y, 127, 31-y);
+            ssd1306_show(&display_01);
             sleep_ms(SLEEPTIME);
-            ssd1306_clear(&disp);
+            ssd1306_clear(&display_01);
             if(y==32) i=-1;
         }
 
         for(int i=0; i<sizeof(words)/sizeof(char *); ++i) {
-            ssd1306_draw_string(&disp, 8, 24, 2, words[i]);
-            ssd1306_show(&disp);
+            ssd1306_draw_string(&display_01, 8, 24, 2, words[i]);
+            ssd1306_show(&display_01);
             sleep_ms(800);
-            ssd1306_clear(&disp);
+            ssd1306_clear(&display_01);
         }
 
         for(int y=31; y<63; ++y) {
-            ssd1306_draw_line(&disp, 0, y, 127, y);
-            ssd1306_show(&disp);
+            ssd1306_draw_line(&display_01, 0, y, 127, y);
+            ssd1306_show(&display_01);
             sleep_ms(SLEEPTIME);
-            ssd1306_clear(&disp);
+            ssd1306_clear(&display_01);
         }
 
         for(size_t font_i=0; font_i<sizeof(fonts)/sizeof(fonts[0]); ++font_i) {
@@ -95,15 +108,15 @@ void animation(void) {
                 }
                 buf[i]=0;
 
-                ssd1306_draw_string_with_font(&disp, 8, 24, 2, fonts[font_i], buf);
-                ssd1306_show(&disp);
+                ssd1306_draw_string_with_font(&display_01, 8, 24, 2, fonts[font_i], buf);
+                ssd1306_show(&display_01);
                 sleep_ms(800);
-                ssd1306_clear(&disp);
+                ssd1306_clear(&display_01);
             }
         }
 
-        ssd1306_bmp_show_image(&disp, image_data, image_size);
-        ssd1306_show(&disp);
+        ssd1306_bmp_show_image(&display_01, image_data, image_size);
+        ssd1306_show(&display_01);
         sleep_ms(2000);
     }
 }

--- a/font.h
+++ b/font.h
@@ -1,5 +1,6 @@
 #ifndef _inc_font
 #define _inc_font
+#include <stdint.h>
 
 /*
  * Format

--- a/font_struct.h
+++ b/font_struct.h
@@ -1,0 +1,14 @@
+#ifndef _font_struct_h
+#define _font_struct_h
+#include <stdint.h>
+/**
+ * Struct that holds a font and all relevant information
+ */
+typedef struct {
+    uint16_t bytes_per_char; // the size of the char sprite in bytes (including padding)
+    uint16_t char_width; // width of the caracter in pixels (how many columns the sprite spans)
+    char first_char_in_font;
+    uint16_t char_height; // height of the character in pixels (how many rows the sprite spans)
+    const char *bitmap_buffer;
+} font;
+#endif

--- a/font_struct.h
+++ b/font_struct.h
@@ -7,7 +7,7 @@
 typedef struct {
     uint16_t bytes_per_char; // the size of the char sprite in bytes (including padding)
     uint16_t char_width; // width of the caracter in pixels (how many columns the sprite spans)
-    char first_char_in_font;
+    char first_char_in_font; // the first char that is included in the font
     uint16_t char_height; // height of the character in pixels (how many rows the sprite spans)
     const char *bitmap_buffer;
 } font;

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -219,14 +219,6 @@ void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_
     }
 }
 
-void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c) {
-    ssd1306_draw_char_with_font(p, x, y, scale, font_8x5, c);
-}
-
-void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s) {
-    ssd1306_draw_string_with_font(p, x, y, scale, font_8x5, s);
-}
-
 static inline uint32_t ssd1306_bmp_get_val(const uint8_t *data, const size_t offset, uint8_t size) {
     switch(size) {
     case 1:

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -30,6 +30,7 @@ SOFTWARE.
 
 #ifndef _inc_ssd1306
 #define _inc_ssd1306
+#include <stdint.h>
 #include <pico/stdlib.h>
 #include <hardware/i2c.h>
 
@@ -238,17 +239,6 @@ void ssd1306_bmp_show_image(ssd1306_t *p, const uint8_t *data, const long size);
 void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, char c);
 
 /**
-	@brief draw char with builtin font
-
-	@param[in] p : instance of display
-	@param[in] x : x starting position of char
-	@param[in] y : y starting position of char
-	@param[in] scale : scale font to n times of original size (default should be 1)
-	@param[in] c : character to draw
-*/
-void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c);
-
-/**
 	@brief draw string with given font
 
 	@param[in] p : instance of display
@@ -261,14 +251,16 @@ void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, cha
 void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, const char *s );
 
 /**
-	@brief draw string with builtin font
+	@brief Blit a sprite into the display buffer
 
-	@param[in] p : instance of display
-	@param[in] x : x starting position of text
-	@param[in] y : y starting position of text
-	@param[in] scale : scale font to n times of original size (default should be 1)
-	@param[in] s : text to draw
-*/
-void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s);
-
+	@param[in] disp : instance of display with display buffer
+	@param[in] sprite : the buffer containing the sprite (padded if necessary)
+	@param[in] sprite_height : the height of the sprite in pixels
+	@param[in] sprite_width : the width of the sprite in pixels (number of columns)
+	@param[in] start_col : the column on the display containing the top left corner of the sprite
+	@param[in] start_row : the row containing the top left corner of the sprite
+ */
+void ssd1306_blit(ssd1306_t *disp, const char* sprite,
+		  uint32_t sprite_height, uint32_t sprite_width,
+		  uint32_t start_col, uint32_t start_row);
 #endif


### PR DESCRIPTION
So this is a bit of a large pull request, as it combines two changes.
1) a modification to the fonts that adds a struct to the font definition and 
removes magic numbers (the indices of the font metadata in the font buffer) from the code replacing them with the name of the struct members.
2) Add a build time flag to allow to use the DMA engine in the Pi to transfer the data to the display buffer instead of doing this with blocking routines of the i2c part of the SDK.