### PR TITLE
Fix swap function

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -34,9 +34,9 @@ SOFTWARE.
 #include "font.h"
 
 inline static void swap(int32_t *a, int32_t *b) {
-    int32_t *t=a;
+    int32_t t=*a;
     *a=*b;
-    *b=*t;
+    *b=t;
 }
 
 inline static void fancy_write(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, char *name) {


### PR DESCRIPTION
Saves the value of pointer `a` to a temp `t` instead of the pointer itself, then puts that back into `b`.

Explanation:
The swap function was saving the pointer `a` to a temporary pointer `t`, then changing the value pointed by `a` (and thus also `t`) to the value pointed by `b`, then putting the value pointed by the temporary value `t` (which became the content of `b` after `*a = *b` since both `t` and `a` were the same pointer) resulting in both `a` and `b` having the same value (of `b`). 
This would cause the function `ssd1306_draw_line` to only render a single dot at `(x2, y2)` if `x1` was greater than `x2` or `(x1,y2)` if `x1` was equal to `x2`.